### PR TITLE
Fix parameter assignment and StringIO import

### DIFF
--- a/RBS_Calculator.py
+++ b/RBS_Calculator.py
@@ -1019,7 +1019,7 @@ def calc_dG_pre_post_RBS(pre_list,post_list,RBS_list,name_list,output,verbose = 
             elif key == "energy_cutoff":
                 test.energy_cutoff = value
             elif key == "standby_site_length":
-                test.standby_sitRBSe_length = value
+                test.standby_site_length = value
             elif key == "dangles":
                 test.dangles = value
             elif key == "export_PDF":

--- a/Run_RBS_Design.py
+++ b/Run_RBS_Design.py
@@ -67,9 +67,9 @@ def run():
     return (True,output_string)
 
 def ReadOutput(output):
-    import stringIO
+    from io import StringIO
 
-    handle = stringIO.stringIO(output)
+    handle = StringIO(output)
 
     for line in handle.readlines():
         if line == "Program Executed":


### PR DESCRIPTION
## Summary
- correct standby site length assignment in `RBS_Calculator`
- use the proper `StringIO` import in `Run_RBS_Design`

## Testing
- `python -m py_compile RBS_Calculator.py` *(fails: Missing parentheses in call to 'print')*
- `python -m py_compile Run_RBS_Design.py` *(fails: Missing parentheses in call to 'print')*

------
https://chatgpt.com/codex/tasks/task_e_68407adff010832195b786a187ae3eb9